### PR TITLE
Start frontend by default on port 9000

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ npm install
 ```
 npm start
 ```
-* By default the App is running on http://localhost:8000/app/
+* By default the App is running on http://localhost:9000/app/
 * Running Tests:
 ```
 npm test

--- a/server.js
+++ b/server.js
@@ -11,7 +11,7 @@
  * Configuration: Put the domains of the services in the development.json
  * Start: node server.js [port]
  *
- * Default port is 8000
+ * Default port is 9000
  *
  */
 var http = require("http"),
@@ -20,7 +20,7 @@ var http = require("http"),
 	fs = require("fs"),
 	httpProxy = require('http-proxy'),
 	nconf = require('nconf'),
-	port = process.argv[2] || 8000;
+	port = process.argv[2] || 9000;
 
 nconf.file('development.json');
 


### PR DESCRIPTION
Port 8000 is used by Django by default, so we should use something else
for the node frontend in order to avoid conflicts by default.
