### PR TITLE
Node: set correct mime types

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
         "http-proxy": "",
         "nconf": "",
         "karma": "~0.10",
-        "bower": ">=1.3.8"
+        "bower": ">=1.3.8",
+        "mime": ""
     },
     "scripts": {
         "start": "node server.js",

--- a/server.js
+++ b/server.js
@@ -20,6 +20,7 @@ var http = require("http"),
 	fs = require("fs"),
 	httpProxy = require('http-proxy'),
 	nconf = require('nconf'),
+	mime = require('mime'),
 	port = process.argv[2] || 9000;
 
 nconf.file('development.json');
@@ -76,7 +77,7 @@ http.createServer(function(request, response) {
 					return;
 				}
 
-				response.writeHead(200);
+				response.writeHead(200, {"Content-Type": mime.lookup(filename)});
 				response.write(file, "binary");
 				response.end();
 			});


### PR DESCRIPTION
As a side effect, this removes all the warnings in the debug console
stating:

> Resource interpreted as script but transferred with MIME type
> text/plain.
