### PR TITLE
Remove central error handling for better debugging

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -40,18 +40,4 @@ var pcApp = angular.module('pcApp', pcAppDependencies)
 .run(function($http, $rootScope, $location, $translate) {
     $http.defaults.headers.common.Authorization = 'Token 1';
     $rootScope.location = $location;
-
-})
-
-/**
- * Very simple central error handling
- */
-    .factory('$exceptionHandler', ['$injector', '$log',  function ($injector, $log) {
-        return function (exception, cause) {
-            // Use the dialogs module to display error messages
-            var dialogs =  $injector.get("dialogs");
-            dialogs.notify("Error", String(exception.message));
-            $log.error(cause);
-            $log.error(exception);
-        };
-    }]);
+});


### PR DESCRIPTION
As far as I experience, the central exception handler obfuscates the
error traceback, as it just redisplays the main error message, but not
the stack trace.

As I need to see in the inspector console where an error comes from, I
removed the central error handling.

If that can be done in a way that doesn't take away the stack trace
information, or if I understood something wrong, feel free to reject
this.