### PR TITLE
Do not proxy API requests

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -7,14 +7,16 @@
  * injection, this should be fixed.
  */
 
+var djangoServicesBaseUrl = 'http://localhost:8000/api/v1/';
+
 var policyCompassConfig = {
     'URL': '/api/v1',
-    'METRICS_MANAGER_URL': '/api/v1/metricsmanager',
-    'VISUALIZATIONS_MANAGER_URL': '/api/v1/visualizationsmanager',
-    'EVENTS_MANAGER_URL': '/api/v1/eventsmanager',
-    'REFERENCE_POOL_URL': '/api/v1/references',
-    'FCM_URL': '/api/v1/fcmmanager',
-    'ELASTIC_URL' : '/policycompass_search',
+    'METRICS_MANAGER_URL': djangoServicesBaseUrl + 'metricsmanager',
+    'VISUALIZATIONS_MANAGER_URL': djangoServicesBaseUrl + 'visualizationsmanager',
+    'EVENTS_MANAGER_URL': djangoServicesBaseUrl + 'eventsmanager',
+    'REFERENCE_POOL_URL': djangoServicesBaseUrl + 'references',
+    'FCM_URL': 'http://localhost:8080/api/v1/fcmmanager',
+    'ELASTIC_URL' : 'http://localhost:9200/policycompass_search',
     'ENABLE_ADHOCRACY': false,
     'ADHOCRACY_URL': 'http://localhost:6551'
 };

--- a/server.js
+++ b/server.js
@@ -5,8 +5,6 @@
  * Author: Fabian Kirstein 2014
  *
  * This is a small Node.js web server for development.
- * It includes a Proxy functionality to proxy the external services. This
- * is necessary due to the Same-Origin-Policy.
  *
  * Configuration: Put the domains of the services in the development.json
  * Start: node server.js [port]
@@ -18,18 +16,9 @@ var http = require("http"),
 	url = require("url"),
 	path = require("path"),
 	fs = require("fs"),
-	httpProxy = require('http-proxy'),
-	nconf = require('nconf'),
     mime = require('mime'),
 	port = process.argv[2] || 9000;
 
-nconf.file('development.json');
-
-var pcServicesUrl = nconf.get('PC_SERVICES_URL');
-var elasticSearchUrl = nconf.get('ELASTIC_SEARCH_URL');
-var fcmServicesUrl = nconf.get('FCM_SERVICES_URL');
-
-var proxy = httpProxy.createServer();
 
 // Heavily inspired by this Gist: https://gist.github.com/rpflorence/701407
 http.createServer(function(request, response) {
@@ -39,37 +28,10 @@ http.createServer(function(request, response) {
 
 	console.log('[%s] "%s %s" "%s"', (new Date).toUTCString(), request.method, request.url, request.headers['user-agent']);
 
-	//Proxy all requests for the metrics service to the Data Manager
-	// /api/v*/metrics
-	if (/^\/api\/v[0-9]+\/metricsmanager/.exec(request.url)) {
-	    proxy.web(request, response, {
-	      target: pcServicesUrl
-	    });
-	} else if (/^\/api\/v[0-9]+\/visualizationsmanager/.exec(request.url)) {
-	    proxy.web(request, response, {
-	      target: pcServicesUrl
-	    });
-	} else if (/^\/api\/v[0-9]+\/eventsmanager/.exec(request.url)) {
-        proxy.web(request, response, {
-            target: pcServicesUrl
-        });
-    } else if (/^\/api\/v[0-9]+\/references/.exec(request.url)) {
-        proxy.web(request, response, {
-            target: pcServicesUrl
-        });
-    } else if (/^\/api\/v[0-9]+\/fcmmanager/.exec(request.url)) {
-        proxy.web(request, response, {
-            target: fcmServicesUrl
-        });
-    } else if (/^\/policycompass_search/.exec(request.url)) {
-        proxy.web(request, response, {
-            target: elasticSearchUrl
-        });
-    } else if (/^\/(app|)$/.exec(request.url)) {
+    if (/^\/(app|)$/.exec(request.url)) {
         response.writeHead(302, {"location": "/app/"});
         response.end();
-    }
-    else {
+    } else {
 
 		fs.exists(filename, function(exists) {
 			if(!exists) {


### PR DESCRIPTION
Remove proxy from node setup, because it makes things unnecessarily
complex.

This was introduced to avoid same-origin-policy issues, however they
should be fixed on the API server side by setting appropriate CORS
headers (basicall accept all).

This has already been done for the django services in policycompass/policycompass-services#2.

It might also need to be done in the other services:

* FCM: haven't checked yet
* Elasticsearch: [Looks like](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/modules-http.html) appropriate CORS headers are already sent by default.