### PR TITLE
Fix Wrong Links in Main Menu

### DIFF
--- a/app/header.html
+++ b/app/header.html
@@ -33,8 +33,8 @@
 <div class="fonticon fonticon-close" ng-click="i=0"></div>
 <ul>
     <li> <a href="#/create-dataset" class="fonticon font-icon-datasets" ng-click="i=0">Upload Datasets</a> </li>
-    <li> <a href="#/create-formula" class="fonticon font-icon-properties" ng-click="i=0">Define Indicators</a> </li>
-    <li> <a href="#/metrics/create" class="fonticon font-icon-metrics" ng-click="i=0">Define Metrics</a> </li>
+    <li> <a href="#/indicators/create" class="fonticon font-icon-properties" ng-click="i=0">Define Indicators</a> </li>
+    <li> <a href="#/create-formula" class="fonticon font-icon-metrics" ng-click="i=0">Define Metrics</a> </li>
     <li> <a href="#/events/create" class="fonticon font-icon-historical_events" ng-click="i=0">Register Historical Events</a> </li>
     <li> <a href="#/visualizations/create" class="fonticon font-icon-visualisation" ng-click="i=0">Visualise Data</a> </li>
     <li> <a href="#/models/create" class="fonticon font-icon-causal_models" ng-click="i=0">Create Causal Models</a> </li>


### PR DESCRIPTION
Due to a merge the links in the main menu were wrong. The link to "Define Indicator" was set to "Create Metric". This PR corrects this. 