### PR TITLE
Add redirect from old metrics route to new one

### DIFF
--- a/app/modules/metrics/metrics.js
+++ b/app/modules/metrics/metrics.js
@@ -23,6 +23,9 @@ metrics.config(function($routeProvider) {
         .when('/metrics', {
             redirectTo: '/browse/metric'
         })
+        .when('/metrics/create', {
+            redirectTo: '/metrics/create-1'
+        })
         .when('/metrics/create-1', {
             controller: 'CreateMetric1Controller',
             templateUrl: 'modules/metrics/partials/create-metric-1.html'


### PR DESCRIPTION
- fixes the "I want to" dialogues
- makes route names consistent with other modules