### PR TITLE
Better Action When Clicking on Legend Item, issue 316

### DIFF
--- a/app/modules/visualization/controllers/visualizationControllers.js
+++ b/app/modules/visualization/controllers/visualizationControllers.js
@@ -5061,7 +5061,7 @@ angular.module('pcApp.visualization.controllers.visualization', [
 	$scope.createVisualization = function(metricListIn) {
 		//console.log("...createVisualization Edit controller")
 		//alert("ssssssssssssssssss");
-        $scope.visualization.user_id = 1;        				     
+        //$scope.visualization.user_id = 1;                				     
         $scope.visualization.views_count = 0;
         $scope.visualization.visualization_type_id = 1;
         
@@ -5636,7 +5636,7 @@ function($scope, $route, $routeParams, $modal, Event, Metric, Dataset, Visualiza
 			
 			//console.log(metricListIn);
 			
-	        $scope.visualization.user_id = 1;        				     
+	        //$scope.visualization.user_id = 1;        				     
 	        $scope.visualization.views_count = 0;
 	        $scope.visualization.visualization_type_id = 1;
 	        

--- a/app/modules/visualization/controllers/visualizationControllers.js
+++ b/app/modules/visualization/controllers/visualizationControllers.js
@@ -1585,6 +1585,16 @@ angular.module('pcApp.visualization.controllers.visualization', [
 			
 			if (action=='datasets')
 			{
+				if ($scope.ListMetricsFilter.length>0)
+				{
+					$scope.tab1 = false;
+					$scope.tab2 = true;
+				}
+				else
+				{
+					$scope.tab1 = true;
+					$scope.tab2 = false;					
+				}
 				$scope.name = 'Link datasets';
 				$scope.opts = {
 					backdrop: true,

--- a/app/modules/visualization/js/objectLine.js
+++ b/app/modules/visualization/js/objectLine.js
@@ -1652,6 +1652,56 @@ return 0;}
 	      				//$('input[name="posx"]').val(posX);
 						//$('input[name="posy"]').val(posY);		
 	      				//$('#basic-modal-content').modal();
+
+						if (self.modeGraph=='view')
+						{
+							
+						}
+						else
+						{
+							if (self.xaxeformat=='sequence')
+							{
+								
+							}
+							else
+							{
+								var posMouse = d3.mouse(this);
+								var posX = posMouse[0];
+								posX = posX + self.margin.left;
+								var posY = posMouse[1];		
+								var maxPosX = self.width + self.margin.left;
+								var posXinvers = "";
+								if (posX>maxPosX)
+								{					
+									posXinvers = ""
+								}
+								else
+								{
+									if (self.xScale)
+									{
+										posXinvers = self.xScale.invert(posX-self.margin.left);
+										//posXinvers = self.xScaleInversa(posX-self.margin.left);
+										var format = d3.time.format("%m-%d-%Y");
+										posXinvers= format(posXinvers);
+										posXinvers = posXinvers.replace(/-/g,"/");
+									}
+								}			
+								
+								var format = d3.time.format("%m-%d-%Y");
+								var maxDateGraph = format(self.maxDate);
+								maxDateGraph = maxDateGraph.replace(/-/g,"/");
+								
+				      			//$('input[name="startDate"]').val(posXinvers);      			
+				      			$('input[name="startDatePosX"]').val(posXinvers);       			     	
+				      			$('input[name="endDatePosX"]').val(maxDateGraph);
+      							
+      							console.log(posXinvers);
+      							console.log(maxDateGraph);
+      							
+								document.getElementById("addHEbutton").click();	
+							}
+						}
+
 	      				
 	      			})
 	      			;	
@@ -1801,7 +1851,7 @@ return 0;}
 								tooltip.style("opacity",1.0).html("Click over to show "+str);
 							}
 							
-						}
+						}						
 												
       					})
 					.on("mouseout", function() {
@@ -1951,6 +2001,17 @@ return 0;}
 	                		d3.select(this).text(res);
 	                		
                 		}
+                		else
+						{
+							if (self.xaxeformat=='sequence')
+							{
+								
+							}
+							else
+							{
+								document.getElementById("modaladddataset").click();	
+							}
+						}
                 	})  
                 	
 			}
@@ -2366,6 +2427,53 @@ return 0;}
                     	//document.getElementById("container_graph_6").innerHTML = "";
                     	//self.init();
                     	//self.drawLines(self.linesIn,self.eventsData);	
+                    	
+						if (self.modeGraph=='view')
+						{
+							
+						}
+						else
+						{
+							if (self.xaxeformat=='sequence')
+							{
+								
+							}
+							else
+							{
+								var posMouse = d3.mouse(this);
+								var posX = posMouse[0];
+								posX = posX + self.margin.left;
+								var posY = posMouse[1];		
+								var maxPosX = self.width + self.margin.left;
+								var posXinvers = "";
+								if (posX>maxPosX)
+								{					
+									posXinvers = ""
+								}
+								else
+								{
+									if (self.xScale)
+									{
+										posXinvers = self.xScale.invert(posX-self.margin.left);
+										//posXinvers = self.xScaleInversa(posX-self.margin.left);
+										var format = d3.time.format("%m-%d-%Y");
+										posXinvers= format(posXinvers);
+										posXinvers = posXinvers.replace(/-/g,"/");
+									}
+								}			
+								
+								var format = d3.time.format("%m-%d-%Y");
+								var maxDateGraph = format(self.maxDate);
+								maxDateGraph = maxDateGraph.replace(/-/g,"/");
+								
+				      			//$('input[name="startDate"]').val(posXinvers);      			
+				      			$('input[name="startDatePosX"]').val(posXinvers);       			     	
+				      			$('input[name="endDatePosX"]').val(maxDateGraph);
+				      											
+								document.getElementById("addHEbutton").click();	
+							}
+						}                    	
+                    	
 					})
 					.transition()
 						.attr("r", self.radius)
@@ -2683,7 +2791,7 @@ return 0;}
       			else
       			{
       				
-      			
+      			/*
 				var posMouse = d3.mouse(this);
 				var posX = posMouse[0];
 				var posY = posMouse[1];		
@@ -2716,6 +2824,7 @@ return 0;}
 				//dateToSet = posXinvers;
 				//console.log("dateToSet="+dateToSet);
       			//$('#basic-modal-content').modal();
+      			*/
       			}
       		})      		
 			.append("g")

--- a/app/modules/visualization/partials/addDataset.html
+++ b/app/modules/visualization/partials/addDataset.html
@@ -7,12 +7,12 @@
 	<div id="basic-modal-content-pc">
 
 		<tabset>
-			<tab heading="Search Datasets">
+			<tab heading="Add Datasets" active="tab1" >
 				<div class="row createvisualization">
 					<div indexdataset="indexdataset" id="filterDatasets"  class="selectorDatasets" datasets-list="ListMetricsFilter" number-Max-Datasets="99" functionfordataset="rePlotGraphFromSearch(actionDone,position)" disable-Row="arrayResolutionsFilter[resolution.value]"></div>
 				</div>
 			</tab>
-			<tab heading="Datasets Configuration">
+			<tab heading="Datasets Configuration" active="tab2">
 				<div class="row createvisualization">
 					<div ng-show="ListMetricsFilter.length==0">No dataset linked</div>
 					<div ng-show="metric.title" ng-controller="LoadCombosMetric" class="designer-metrics active" class="designer-metrics" id="designer-metrics-num-{{metric.id}}" ng-repeat="metric in ListMetricsFilter track by $index" >
@@ -22,12 +22,16 @@
 						<input type="hidden" ng-model="MetricSelectediIndex_[metric.id]" ng-init="MetricSelectediIndex_[metric.id]=metric.id" id="MetricSelectediIndex_{{metric.id}}" name="MetricSelectediIndex[]" value="{{metric.id}}">
 
 						<div class="metric-buttons">
-							<a type="button" data-intro="Edit dataset view properties" data-position="top" class="btn btn-primary btn-create" ng-click="displaycontentMetricModal(metric.id);collapsetFilterDataset=!collapsetFilterDataset;" id="modal-edit-metric-button-{{metric.id}}"><span ng-hide="collapsetFilterDataset">Open</span><span ng-show="collapsetFilterDataset">Collapse</span> Edit Mode</a>											    	
+							<!--
+							<a type="button" data-intro="Edit dataset view properties" data-position="top" class="btn btn-primary btn-create" ng-click="displaycontentMetricModal(metric.id);collapsetFilterDataset=!collapsetFilterDataset;" id="modal-edit-metric-button-{{metric.id}}"><span ng-hide="collapsetFilterDataset">Open</span><span ng-show="collapsetFilterDataset">Collapse</span> Edit Mode</a>
+							-->											    	
 					    	<button type="button" data-intro="Remove dataset from the visualisation" data-position="top" class="btn btn-danger btn-clear" ng-click="deleteMetricFromList(metric.id, metric.title, ListMetricsFilter, $index);" id="delete-metric-button-{{metric.id}}">Remove</button>						    	
 					    	<a type="button" data-intro="Access to the dataset data" data-position="right" class="btn btn-info btn-adddataset" href="#!/datasets/{{metric.id}}" target="_blank" id="view-metric-button-{{metric.id}}">View Dataset in detaill</a>						    	
 					  	</div>
-
+						<!--
 						<div class="metric-forms" style="display: none;">
+						-->
+						<div class="metric-forms">
 							<div class="metric-form-item">
 								<br>
 								<table>

--- a/app/modules/visualization/partials/create.html
+++ b/app/modules/visualization/partials/create.html
@@ -10,7 +10,7 @@
     			<p>
     				To create a visualisation you need to:
 					<ul>
-						<li>Select which dataset (one or more) do you wish to use. Use the "Link Datasets" button to do it.</li>
+						<li>Select which dataset (one or more) do you wish to use. Use the "Configure Datasets" button to do it.</li>
 						<li>Select the type of chart you want using the appropiate button:
 							<ul>
 								<li>"Map" To plot as a map chart.</li>								
@@ -48,7 +48,7 @@
 					<button type="submit" data-intro="Revert data" data-position="top" class="btn btn-default btn-revert" ng-click="revertVisualization()">Revert</button>
 					
 					
-				<button data-intro="Helps you to link datasets with this visualisation" data-position="top" type="submit" class="btn btn-default btn-adddataset" id="modaladddataset" ng-click="showModal('datasets')">Link Datasets</button>
+				<button data-intro="Helps you to configure datasets with this visualisation" data-position="top" type="submit" class="btn btn-default btn-adddataset" id="modaladddataset" ng-click="showModal('datasets')">Configure Datasets</button>
 				
 				
 				<button ng-show="isSelectedSon('graph_line') && ListMetricsFilter.length>0" data-intro="Helps you to link this visualisation with events" data-position="top"  type="submit" class="btn btn-primary btn-adddevent" id="addHEbutton" ng-click="showModal('events')">Link Events</button>
@@ -78,8 +78,10 @@
 	            	<div ng-show="((1==1)  || isSelectedSon('graph_line') || isSelectedSon('graph_pie') || isSelectedSon('graph_bars')) && (ListMetricsFilter.length>0)" class="graphContainerdiv">
 						<input type="hidden" id="startDatePosX" name="startDatePosX" value="">
 						<input type="hidden" id="endDatePosX" name="endDatePosX" value="">
- 		
+ 							<!--
 							<div ng-click="isSelectedSon('graph_line') ? showModal('events') : void(0)">
+							-->
+							<div>
 								<div ng-show="isSelectedSon('map_1') || isSelectedSon('mercator') || isSelectedSon('conicConformal') || isSelectedSon('equirectangular') || isSelectedSon('orthographic') || isSelectedSon('azimuthalEqualArea')">
 									<div ng-show="mapTimeSlider.length>0">
 										<rzslider


### PR DESCRIPTION
Better action when clicking on Legend in edit mode issue 316 ( policycompass/policycompass#316)

In edit mode, when you click over the legend the modal window that enable you to update datesets configuration is open.

In edit mode, you need to click over lines or over points to open de modal window that helps you to configure historical events.

Reanme buttons:
1) rename the button "Link Datasets" to "Configure Datasets"
2) rename the tab "Search Datasets" to "Add Datasets"