### PR TITLE
update cancel alert message and solve problem with pre-selected individuals

### DIFF
--- a/app/modules/visualization/controllers/visualizationControllers.js
+++ b/app/modules/visualization/controllers/visualizationControllers.js
@@ -119,6 +119,26 @@ angular.module('pcApp.visualization.controllers.visualization', [
 	
 }])
 
+.controller('LoadCombosMetricModal', [
+	'$scope', 
+	'$route',
+	'$routeParams',
+	'$modal',  
+	'Metric', 
+	'Dataset',
+	'$location', 
+	'GetRelatedData',
+	'dialogs',
+	'$log', 
+	'API_CONF',
+	'Individual',
+	'Unit',
+	function($scope, $route, $routeParams, $modal, Metric, Dataset, $location, helper, dialogs, $log, API_CONF, Individual, Unit) {
+		
+
+}])
+
+
 .controller('LoadCombosMetric', [
 	'$scope', 
 	'$route',
@@ -134,12 +154,10 @@ angular.module('pcApp.visualization.controllers.visualization', [
 	'Individual',
 	'Unit',
 	function($scope, $route, $routeParams, $modal, Metric, Dataset, $location, helper, dialogs, $log, API_CONF, Individual, Unit) {
-
-		
         
 		//console.log("LoadCombosMetric");
     	//helper.baseGetRelatedDataController($scope, $route, $routeParams, $modal, Event, Metric, Visualization, $location, helper, $log, API_CONF);
-    	
+    	//console.log($scope.LoadCombosMetricExecuted);
     	//$scope.DatasetsLoaded = [];
     	if ($scope.LoadCombosMetricExecuted!=1)
     	{
@@ -1500,7 +1518,7 @@ angular.module('pcApp.visualization.controllers.visualization', [
 			// Open a confirmation dialog
         	var dlg = dialogs.confirm(
             	"Are you sure?",
-            	"Do you want to exit without save this visualization?");
+            	"Do you want to exit without saving this visualization?");
         	dlg.result.then(function () {
 
 				if ($scope.mode=='create')
@@ -1699,12 +1717,14 @@ angular.module('pcApp.visualization.controllers.visualization', [
 					$scope.tab2 = false;					
 				}
 				$scope.name = 'Link datasets';
+				
+				//to avoid modal in cache we add a random in to the url
 				$scope.opts = {
 					backdrop: true,
 					backdropClick: false,
 					dialogFade: true,
 					keyboard: true,        
-					templateUrl : 'modules/visualization/partials/addDataset.html',
+					templateUrl : 'modules/visualization/partials/addDataset.html?bust='+ Math.random().toString(36).slice(2),
 			        controller : 'ModalInstanceCtrlDataset',
 					resolve: {}, // empty storage
 					scope: $scope
@@ -1908,13 +1928,14 @@ angular.module('pcApp.visualization.controllers.visualization', [
 				//$scope.startDateToFilter = '2014-09-17';
 				//$scope.startDateToFilter = $scope.startDate ;
 				//$scope.startDateToFilter = "Mon Sep 15 2014 00:00:00 GMT+0200 (Romance Daylight Time)";
-						
+				
+				//to avoid modal in cache we add a random in the path
 		        $scope.opts = {
 					backdrop: true,
 					backdropClick: false,
 					dialogFade: true,
 					keyboard: true,        
-					templateUrl : 'modules/visualization/partials/addEvent.html',
+					templateUrl : 'modules/visualization/partials/addEvent.html?bust='+ Math.random().toString(36).slice(2),
 			        controller : 'ModalInstanceCtrl',
 					resolve: {}, // empty storage
 					scope: $scope

--- a/app/modules/visualization/partials/addDataset.html
+++ b/app/modules/visualization/partials/addDataset.html
@@ -15,7 +15,7 @@
 			<tab heading="Datasets Configuration" active="tab2">
 				<div class="row createvisualization">
 					<div ng-show="ListMetricsFilter.length==0">No dataset linked</div>
-					<div ng-show="metric.title" ng-controller="LoadCombosMetric" class="designer-metrics active" class="designer-metrics" id="designer-metrics-num-{{metric.id}}" ng-repeat="metric in ListMetricsFilter track by $index" >
+					<div ng-show="metric.title" ng-controller="LoadCombosMetricModal" class="designer-metrics active" class="designer-metrics" id="designer-metrics-num-{{metric.id}}" ng-repeat="metric in ListMetricsFilter track by $index" >
 						<h4>{{metric.title}} -- {{metric.issued | date:'longDate' }}</h4>	
 
 						<input type="hidden" ng-model="MetricSelectediId_[metric.id]" id="MetricSelectediId_{{metric.id}}" name="MetricSelectedId[]" value="">


### PR DESCRIPTION
This PR is to update the alert message that appears when a user click the button "cancel" when is editing a visualisation.

The text "Do you want to exit without save this visualization?" has been uptated as "Do you want to exit without saving this visualization?"

and also this PR solves an issue with the pre-selected invividuals (The issue is: Each time the modal window that enable users to config datasets and individuals is opened, all the individals are checked by default).


