### PR TITLE
Redirect to previous page after login / register

### DIFF
--- a/app/modules/auth/services/auth.js
+++ b/app/modules/auth/services/auth.js
@@ -11,6 +11,25 @@ angular.module('pcApp.auth.services.auth', [
         '$q',
         function (Adhocracy, API_CONF, $rootScope, $http, $location, $q) {
 
+            var last = undefined;
+
+            $rootScope.$on("$locationChangeSuccess",
+                function(evt, nextUrl, prevUrl) {
+                    /* FIXME: Is there a more generic way to get the path
+                     * from the URL? */
+                    var next = nextUrl.split("#!")[1];
+                    var prev = prevUrl.split("#!")[1];
+
+                    if ((next == "/login" || next == "/register")
+                        && typeof prev !== "undefined"
+                        && prev !== "/login"
+                        && prev !== "/register"
+                    ) {
+                        last = prev;
+                    }
+                }
+            );
+
             var Auth = {
                 state: {
                     loggedIn: undefined,
@@ -67,7 +86,8 @@ angular.module('pcApp.auth.services.auth', [
                     Auth._login(data.userData, data.token, data.userPath).then(function (ready) {
 
                         if (($location.path() === '/login') || ($location.path() === '/register')) {
-                            $location.path('/');
+                            $location.path(last || '/');
+                            last = undefined;
                         }
                     });
                 });

--- a/app/modules/auth/services/auth.js
+++ b/app/modules/auth/services/auth.js
@@ -23,10 +23,11 @@ angular.module('pcApp.auth.services.auth', [
                 // the AdhocracySDK.
 
                 _login: function (userData, token, userPath) {
-                    $http.get(API_CONF.ADHOCRACY_BACKEND_URL + "/principals/groups/gods/").then(function (response) {
+                    return $http.get(API_CONF.ADHOCRACY_BACKEND_URL + "/principals/groups/gods/").then(function (response) {
                         var godsGroup = response.data;
                         var godsGroupSheet = godsGroup.data["adhocracy_core.sheets.principal.IGroup"];
                         var isAdmin = (_.contains(godsGroupSheet.roles, "god") && _.contains(godsGroupSheet.users, userPath));
+                        var deferred = $q.defer();
 
                         _.defer(function () {
                             $rootScope.$apply(function () {
@@ -37,8 +38,12 @@ angular.module('pcApp.auth.services.auth', [
 
                                 $http.defaults.headers.common["X-User-Token"] = token;
                                 $http.defaults.headers.common["X-User-Path"] = userPath;
+
+                                deferred.resolve(true)
                             });
                         });
+
+                        return deferred.promise;
                     });
                 },
 
@@ -59,11 +64,12 @@ angular.module('pcApp.auth.services.auth', [
 
             Adhocracy.then(function (adh) {
                 adh.registerMessageHandler('login', function (data) {
-                    Auth._login(data.userData, data.token, data.userPath);
+                    Auth._login(data.userData, data.token, data.userPath).then(function (ready) {
 
-                    if (($location.path() === '/login') || ($location.path() === '/register')) {
-                        $location.path('/');
-                    }
+                        if (($location.path() === '/login') || ($location.path() === '/register')) {
+                            $location.path('/');
+                        }
+                    });
                 });
                 adh.registerMessageHandler('logout', function (data) {
                     Auth._logout();


### PR DESCRIPTION
Fixes policycompass/policycompass#313.

This uses the `$locationChangeSuccess` event in order to get the
previous URL and gets the path by splitting the URL at `#!`. This isn't
ideal, as it requires the application to run in hashbang mode and would
break in html5 mode.

Alternatively, the `$routeChangeSuccess` event could be used, but this
would require to the actual path using based on the path templates (e.g.
`/datasets/:datasetId`) and parameters (e.g. `{'dataset': 15}`).

The same could also be done on logout, but I didn't do as it's less
relevant and not clear whether it's actually desired. More importantly,
this wouldn't work if a user visited a restricted page before logout.