### PR TITLE
Fix facets in Firefox

### DIFF
--- a/app/modules/search/partials/browse.html
+++ b/app/modules/search/partials/browse.html
@@ -218,7 +218,7 @@
                 <ul>
                     <li ng-repeat="bucket in facetCategory.buckets">
                         <input type="checkbox" ng-model="bucket.selected" ng-change="facetChanged()" id="{{facetCategory.name}}_{{bucket.value}}">
-                        <label for="{{facetCategory.name}}_{{bucket.value}}" tooltip-placement="right" tooltip="{{ bucket.label }}" tooltip-append-to-body="true"><span class="pull-right">({{bucket.results}})</span>{{ bucket.label}}</label>
+                        <label for="{{facetCategory.name}}_{{bucket.value}}" tooltip-placement="right" tooltip="{{ bucket.label }}" tooltip-append-to-body="true"><span class="pull-right">({{bucket.results}})</span><span class="ellipsis">{{ bucket.label}}</span></label>
                     </li>
                 </ul>
             </div>

--- a/app/sass/components/_pages-search.scss
+++ b/app/sass/components/_pages-search.scss
@@ -228,9 +228,14 @@ $ancho: $unidad * 2;
         width: 100%;
         margin-left: -13px;
         padding-left: 13px;
-        text-overflow: ellipsis;
         overflow: hidden;
         margin-bottom: -3px;
+        .ellipsis {
+            text-overflow: ellipsis;
+            overflow: hidden;
+            display: block;
+            padding-right: 3px;
+        }
     }
     ul {
 


### PR DESCRIPTION
Workaround for cross browser text-overflow with floating element.
Firefox clips the text at the block container edge instead of line box edge, so I've changed the DOM to workaround this issue.
https://github.com/policycompass/policycompass/issues/394