### PR TITLE
Fix logo size in mobile view

### DIFF
--- a/app/sass/components/_pages.scss
+++ b/app/sass/components/_pages.scss
@@ -13,7 +13,7 @@
 
 #logo {
     margin: 10px 0;
-    width: $unidad * 6;
+    width: 30px;
     float: left;
 }
 
@@ -57,7 +57,7 @@
 
 @media (min-width: $device_4) {
     #logo {
-        width: $unidad * 4;
+        // width: $unidad * 4;
     }
 }
 


### PR DESCRIPTION
related with [Issue #493](https://github.com/policycompass/policycompass/issues/493)



Adjust header logo size on small screens
