### PR TITLE
prevent infinite $digest loop

### DIFF
--- a/app/modules/visualization/controllers/visualizationControllers.js
+++ b/app/modules/visualization/controllers/visualizationControllers.js
@@ -1018,7 +1018,9 @@ angular.module('pcApp.visualization.controllers.visualization', [
                         var dlg = dialogs.confirm("Are you sure?", "Do you want to exit without saving this visualization?");
                         dlg.result.then(function () {
                             if ($scope.mode == 'create') {
-                                window.history.back();
+                                $timeout(function(){
+                                    window.history.back();
+                                });
                             } else {
                                 //window.history.back();
                                 $location.path('/visualizations/'+$scope.visualization.id);


### PR DESCRIPTION
Changing window location outside Angular brakes next $digest.
wrapping the change with timeout prevents that.
https://github.com/policycompass/policycompass/issues/508