### PR TITLE
Fixed wring queue.js Import

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -87,7 +87,7 @@
     <script type="text/javascript" src="../bower_components/angular-dialog-service/dist/dialogs.min.js"></script>
     <script type="text/javascript" src="../bower_components/angular-dialog-service/dist/dialogs-default-translations.min.js"></script>
     <script type="text/javascript" src="../bower_components/angular-translate/angular-translate.min.js"></script>
-    <script type="text/javascript" src="../bower_components/queue-async/queue.min.js"></script>
+    <script type="text/javascript" src="../bower_components/queue-async/queue.js"></script>
     <script type="text/javascript" src="../bower_components/d3/d3.min.js"></script>
     <script type="text/javascript" src="../bower_components/underscore/underscore-min.js"></script>
     <script type="text/javascript" src="../bower_components/spectrum/spectrum.js"></script>


### PR DESCRIPTION
The index.html has included queue.min.js. In the versionof this library this file does not exist. https://github.com/mbostock-bower/d3-queue-bower/tree/v1.0.7