### PR TITLE
frontend for the new license model in the referencepool

### DIFF
--- a/app/modules/datasets/controllers/datasetControllers.js
+++ b/app/modules/datasets/controllers/datasetControllers.js
@@ -953,6 +953,10 @@ angular.module('pcApp.datasets.controllers.dataset', [
                     input: creationService.data.dataset.external_resource,
                     output: []
                 };
+                $scope.license = {
+                    input: creationService.data.dataset.license,
+                    output: []
+                };
 
                 $scope.custom = false;
             };
@@ -964,6 +968,7 @@ angular.module('pcApp.datasets.controllers.dataset', [
                 creationService.data.dataset.language = $scope.language.output;
                 creationService.data.dataset.policy_domains = $scope.policy_domains.output;
                 creationService.data.dataset.external_resource = $scope.external_resource.output;
+                creationService.data.dataset.license = $scope.license.output;
                 //creationService.data.dataset =   $scope.dataset;
             };
 
@@ -1029,7 +1034,7 @@ angular.module('pcApp.datasets.controllers.dataset', [
                 payload.title = $scope.dataset.title;
                 payload.acronym = $scope.dataset.acronym;
                 payload.keywords = $scope.dataset.keywords;
-                payload.license = $scope.dataset.license;
+                if($scope.license.output) payload.license_id = $scope.license.output[0];
                 payload.description = $scope.dataset.description;
                 payload.spatials = $scope.spatials.output;
                 payload.language_id = $scope.language.output[0];

--- a/app/modules/datasets/partials/detail.html
+++ b/app/modules/datasets/partials/detail.html
@@ -174,9 +174,11 @@
                             <div class="field-content">{{ dataset.resource.custom }}</div>
                         </a>
                     </div>
-                    <div class="form-item" ng-if="dataset.license">
-                        <div class="field-label">Licence</div>
-                        <div class="field-content">{{ dataset.license }}</div>
+                    <div class="form-item" ng-if="dataset.license_id">
+                        <div class="field-label">License</div>
+                        <div class="field-content">
+                            <span resolve-license id="dataset.license_id"></span>
+                        </div>
                     </div>
                 </div>
 

--- a/app/modules/datasets/partials/edit.html
+++ b/app/modules/datasets/partials/edit.html
@@ -51,9 +51,13 @@
                             </div>
                         </div>
 
-                        <div class="form-group" ng-class="{'has-error': datasetForm.license.$dirty && datasetForm.license.$invalid}">
-                            <label for="license">Licence</label>
-                            <input type="text" class="form-control" id="license" name="license" placeholder="CC BY 3.0" ng-model="dataset.license">
+                        <div class="form-group">
+                            <label for="license">License</label>
+                            <div id="license"
+                                class="reference-selection-form pc-reference-selection-full"
+                                resource="License" selection-mode="single"
+                                ng-model="dataset.license_id" required>
+                            </div>
                         </div>
                     </fieldset>
                 </div>

--- a/app/modules/datasets/partials/step7.html
+++ b/app/modules/datasets/partials/step7.html
@@ -27,9 +27,10 @@
                         <div id="language" class="reference-selection pc-reference-selection-full" resource="Language" selection-mode="single" output="language.output" input="language.input"></div>
                     </div>
 
-                    <div class="form-group" ng-class="{'has-error': datasetForm.license.$dirty && datasetForm.license.$invalid}">
+                    <div class="form-group">
                         <label for="license">Licence</label>
-                        <input type="text" class="form-control" id="license" name="license" placeholder="CC BY 3.0" ng-model="dataset.license" required>
+
+                        <div id="license" class="reference-selection pc-reference-selection-full" resource="License" selection-mode="single" output="license.output" input="license.input"></div>
                     </div>
                 </fieldset>
             </div>

--- a/app/modules/references/directives/forms.js
+++ b/app/modules/references/directives/forms.js
@@ -53,6 +53,26 @@ angular.module('pcApp.references.directives.forms', [
     ])
 
 /**
+ * Returns HTML option tags for the selection of the license
+ */
+    .directive('licenseOptions', [
+        '$log', 'License', function ($log, License) {
+            return {
+                restrict: 'C',
+                scope: {
+                    model: '=model'
+                },
+                controller: function ($scope) {
+                    $scope.licenses = License.query(null, function () {
+                        //$log.info($scope.licenses);
+                    });
+                },
+                template: '<option value="{{ l.id }}" ng-repeat="l in licenses" ng-selected="l.id == model" >{{ l.title }}</option>'
+            };
+        }
+    ])
+
+/**
  * Returns HTML option tags for the selection of the policy domain
  */
     .directive('policydomainOptions', [

--- a/app/modules/references/directives/resolve.js
+++ b/app/modules/references/directives/resolve.js
@@ -78,4 +78,19 @@ angular.module('pcApp.references.directives.resolve', [
                 template: '<span>{{ policydomain.title }}</span>'
             };
         }
+    ])
+
+    .directive('resolveLicense', [
+        '$log', 'License', function ($log, License) {
+            return {
+                scope: {
+                    id: '='
+                },
+                link: function (scope, element, attrs, ctrls) {
+                    scope.license = License.get({id: scope.id}, function () {
+                    });
+                },
+                template: '<a href="{{license.url}}" target="_blank">{{ license.title }}</a>'
+            };
+        }
     ]);

--- a/app/modules/references/services/referenceService.js
+++ b/app/modules/references/services/referenceService.js
@@ -208,5 +208,31 @@ angular.module('pcApp.references.services.reference', [
             };
             return Individual;
         }
-    ]);
+    ])
 
+
+/**
+ * Factory for getting a Class, which connects to the class endpoint
+ */
+    .factory('License', [
+        '$resource', 'API_CONF', function ($resource, API_CONF) {
+            var url = API_CONF.REFERENCE_POOL_URL + "/licenses/:id";
+            var License = $resource(url, {
+                id: "@id"
+            }, {
+                get: {
+                    method: 'GET',
+                    cache: true
+                },
+                query: {
+                    method: 'GET',
+                    cache: true,
+                    isArray: true
+                }
+            });
+            License.getById = function (id) {
+                return this.get({id: id})
+            };
+            return License;
+        }
+    ]);


### PR DESCRIPTION
Requires: https://github.com/policycompass/policycompass-services/pull/141

+ new factory "License" in references
+ new datasets will save licenses as an ID and not as a string anymore