### PR TITLE
filter by unit_category

### DIFF
--- a/app/modules/metrics/partials/apply-metric-2.html
+++ b/app/modules/metrics/partials/apply-metric-2.html
@@ -54,7 +54,7 @@
                 <label for="unit_id" class="field-label">Unit</label>
 
                 <div class="field-content">
-                    <select class="form-control unit-options" ng-model="apply_metric_helper.data.unit_id" id="unit_id" required>
+                    <select class="form-control unit-options" ng-model="apply_metric_helper.data.unit_id" data-category="apply_metric_helper.unit_category_id" id="unit_id" required>
                     </select>
 
                     <p ng-hide="servererror.unit_id || (datasetForm.unit_id.$error.required && !datasetForm.unit_id.$pristine)" class="help-block">Please select the unit for the new dataset</p>


### PR DESCRIPTION
@FabiApfelkern reported an error (which I could not reproduce), that when applying a metric the unit select in step 2 would not show the right units, so I removed the filter for unit_categories with this PR https://github.com/policycompass/policycompass-frontend/pull/283. Now all units are shown. I also added this issue: https://github.com/policycompass/policycompass/issues/404

I checked again, whats happening there: Metrics are saved with an Indicator. Indicators have a Unit Category. A Dataset has a Unit. So when I apply a metric I have to select a unit which should match the indicators unit category I would say. So this what is happening, thats why I changed it back. 

Would be great to get more information on that error.  