### PR TITLE
Rewrite login register flows

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -47,6 +47,10 @@ var pcApp = angular.module('pcApp', pcAppDependencies)
         $rootScope.location = $location;
     })
 
+    .run(['Auth', function(Auth) {
+        Auth.recoverSession()
+    }])
+
 /**
  * Very simple central error handling
  */

--- a/app/app.js
+++ b/app/app.js
@@ -4,6 +4,7 @@
  */
 var pcAppDependencies = [
     'ngRoute',
+    'ngStorage',
     'ui.bootstrap',
     'pcApp.metrics',
     'pcApp.visualization',
@@ -48,7 +49,7 @@ var pcApp = angular.module('pcApp', pcAppDependencies)
     })
 
     .run(['Auth', function(Auth) {
-        Auth.recoverSession()
+        Auth.recoverSession();
     }])
 
 /**

--- a/app/header.html
+++ b/app/header.html
@@ -82,7 +82,7 @@
                 <li id="btn-login" ng-if="!authState.loggedIn" ng-cloak>
                 <a href="#!/login" class="fonticon font-icon-log_in" ng-click="i=0">Log In</a></li>
                 <li ng-if="authState.loggedIn" ng-cloak>
-                <a href="#!/logout" class="fonticon font-icon-log_out" ng-click="i=0">Logout ({{ authState.userData.name }})</a>
+                <a href class="fonticon font-icon-log_out" ng-click="i=0;auth.logout()">Logout ({{ authState.userData.name }})</a>
                 </li>
             </ul>
         </div>

--- a/app/index.html
+++ b/app/index.html
@@ -161,7 +161,7 @@
     <script type="text/javascript" src="modules/auth/auth.js"></script>
     <script type="text/javascript" src="modules/auth/services/auth.js"></script>
     <script type="text/javascript" src="modules/auth/controllers/authControllers.js"></script>
-    <script type="text/javascript" src="modules/auth/directives/login.js"></script>
+    <script type="text/javascript" src="modules/auth/directives/loginRegister.js"></script>
     <script type="text/javascript" src="modules/deliberation/deliberation.js"></script>
     <script type="text/javascript" src="modules/deliberation/directives/showDiscussion.js"></script>
     <script type="text/javascript" src="modules/deliberation/directives/requestService.js"></script>

--- a/app/index.html
+++ b/app/index.html
@@ -157,6 +157,7 @@
     <script type="text/javascript" src="modules/indicators/directives/forms.js"></script>
     <script type="text/javascript" src="modules/adhocracyEmbedder/adhocracyEmbedder.js"></script>
     <script type="text/javascript" src="modules/adhocracyEmbedder/services/adhocracy.js"></script>
+    <script type="text/javascript" src="modules/adhocracyEmbedder/directives/adhocracy.js"></script>
     <script type="text/javascript" src="modules/auth/auth.js"></script>
     <script type="text/javascript" src="modules/auth/services/auth.js"></script>
     <script type="text/javascript" src="modules/auth/controllers/authControllers.js"></script>

--- a/app/modules/adhocracyEmbedder/adhocracyEmbedder.js
+++ b/app/modules/adhocracyEmbedder/adhocracyEmbedder.js
@@ -1,3 +1,4 @@
 angular.module('pcApp.adhocracyEmbedder', [
     'pcApp.adhocracyEmbedder.services.adhocracy',
+    'pcApp.adhocracyEmbedder.directives.adhocracy',
 ]);

--- a/app/modules/adhocracyEmbedder/directives/adhocracy.js
+++ b/app/modules/adhocracyEmbedder/directives/adhocracy.js
@@ -1,11 +1,11 @@
 angular.module('pcApp.adhocracyEmbedder.directives.adhocracy', [])
 
     .directive('adhCrossWindowChannel', [
-        'AdhocracyCrossWindowChannel', function (AdhocracyCrossWindowChannel) {
+        'AdhocracyCrossWindowChannelIframe', function (AdhocracyCrossWindowChannelIframe) {
             return {
                 restrict: 'E',
                 link: function (scope, element, attrs) {
-                    AdhocracyCrossWindowChannel.then(function(iframe) {
+                    AdhocracyCrossWindowChannelIframe.then(function(iframe) {
                         element.append(iframe);
                     });
                 }

--- a/app/modules/adhocracyEmbedder/directives/adhocracy.js
+++ b/app/modules/adhocracyEmbedder/directives/adhocracy.js
@@ -1,15 +1,12 @@
 angular.module('pcApp.adhocracyEmbedder.directives.adhocracy', [])
 
     .directive('adhCrossWindowChannel', [
-        'Adhocracy', function (Adhocracy) {
+        'AdhocracyCrossWindowChannel', function (AdhocracyCrossWindowChannel) {
             return {
                 restrict: 'E',
                 link: function (scope, element, attrs) {
-                    Adhocracy.then(function (adh) {
-                        element.append(adh.getIframe('empty', {
-                            noheader: true,
-                            nocenter: true
-                        }))
+                    AdhocracyCrossWindowChannel.then(function(iframe) {
+                        element.append(iframe);
                     });
                 }
             };

--- a/app/modules/adhocracyEmbedder/directives/adhocracy.js
+++ b/app/modules/adhocracyEmbedder/directives/adhocracy.js
@@ -1,0 +1,17 @@
+angular.module('pcApp.adhocracyEmbedder.directives.adhocracy', [])
+
+    .directive('adhCrossWindowChannel', [
+        'Adhocracy', function (Adhocracy) {
+            return {
+                restrict: 'E',
+                link: function (scope, element, attrs) {
+                    Adhocracy.then(function (adh) {
+                        element.append(adh.getIframe('empty', {
+                            noheader: true,
+                            nocenter: true
+                        }))
+                    });
+                }
+            };
+        }
+    ]);

--- a/app/modules/adhocracyEmbedder/services/adhocracy.js
+++ b/app/modules/adhocracyEmbedder/services/adhocracy.js
@@ -21,4 +21,91 @@ angular.module('pcApp.adhocracyEmbedder.services.adhocracy', [])
             });
             return deferred.promise;
         }
-    ]);
+    ])
+
+    .factory('AdhocracyClient', [
+        '$http', 'API_CONF', function($http, API_CONF) {
+
+            var url = function(path) {
+                if( typeof path !== 'string' ) {
+                    path = path.join('/')
+                }
+                return API_CONF.ADHOCRACY_BACKEND_URL + '/' + path
+            };
+
+            var client = {};
+
+            client.headerNames = {
+                token: 'X-User-Token',
+                userPath: 'X-User-Path'
+            }
+
+            client.create_session = function(usernameOrEmail, password) {
+                var loginUrl, data;
+                if (usernameOrEmail.indexOf('@') === -1) {
+                    var username = usernameOrEmail;
+                    loginUrl = url('login_username');
+                    data = { name: username, password: password };
+                } else {
+                    var email = usernameOrEmail;
+                    loginUrl = url('login_email');
+                    data = { email: email, password: password };
+                }
+
+                return $http({
+                    method: 'POST',
+                    url: loginUrl,
+                    data: data
+                }).then(function (response){
+                    return {
+                        token: response.data.user_token,
+                        userPath: response.data.user_path
+                    }
+                });
+            };
+
+            client.validate_session = function(session) {
+                headers = {}
+                headers[client.headerNames.token] = session.token
+                headers[client.headerNames.userPath] = session.userPath
+
+                return $http({
+                    method: 'GET',
+                    url: session.userPath,   // userPath does store the user url
+                    headers: headers
+                }).then(function (response) {
+                    name = response.data.data['adhocracy_core.sheets.principal.IUserBasic'].name
+                    roles = response.data.data['adhocracy_core.sheets.principal.IPermissions'].roles
+                    email = response.data.data['adhocracy_core.sheets.principal.IUserExtended'].email
+                    return {
+                        name: name,
+                        roles: roles,
+                        email: email
+                    }
+                })
+            };
+
+            client.register = function(username, email, password) {
+                return $http({
+                    method: 'POST',
+                    url: url('/principals/users/'),
+                    data: {
+                        "content_type": "adhocracy_core.resources.principal.IUser",
+                        "data": {
+                            "adhocracy_core.sheets.principal.IUserBasic": {
+                                "name": username
+                            },
+                            "adhocracy_core.sheets.principal.IUserExtended":{
+                                "email": email
+                            },
+                            "adhocracy_core.sheets.principal.IPasswordAuthentication":{
+                                "password": password
+                            }
+                        }
+                    }
+                });
+            }
+
+            return client;
+        }
+    ])

--- a/app/modules/adhocracyEmbedder/services/adhocracy.js
+++ b/app/modules/adhocracyEmbedder/services/adhocracy.js
@@ -7,7 +7,7 @@ angular.module('pcApp.adhocracyEmbedder.services.adhocracy', [])
  *
  * Currently returns a promise, because the init function is asynchronous.
  */
-    .factory('Adhocracy', [
+    .factory('AdhocracySdk', [
         "$q", "API_CONF", function ($q, API_CONF) {
             var deferred = $q.defer();
             $.ajax({
@@ -19,7 +19,30 @@ angular.module('pcApp.adhocracyEmbedder.services.adhocracy', [])
                     });
                 }
             });
-            return deferred.promise;
+            return deferred.promise
+        }
+    ])
+
+    .factory('AdhocracyCrossWindowChannel', [
+        'AdhocracySdk', '$q',
+        function(AdhocracySdk, $q) {
+            return AdhocracySdk.then(function (adh) {
+                var iframeJQuery = adh.getIframe('empty', {
+                    noheader: true,
+                    nocenter: true
+                });
+                var iframe = iframeJQuery[0]
+
+                ﻿iframe.setToken = function (token) {
+                    adh.postMessage(iframe.contentWindow,'setToken', {'token': token})
+                }
+
+                iframe.deleteToken = function () {
+                    adh.postMessage(iframe.contentWindow, 'deleteToken', {})
+                }
+
+                return iframeJQuery;
+            });
         }
     ])
 

--- a/app/modules/adhocracyEmbedder/services/adhocracy.js
+++ b/app/modules/adhocracyEmbedder/services/adhocracy.js
@@ -40,14 +40,14 @@ angular.module('pcApp.adhocracyEmbedder.services.adhocracy', [])
                 userPath: 'X-User-Path'
             }
 
-            client.create_session = function(usernameOrEmail, password) {
+            client.create_session = function(nameOrEmail, password) {
                 var loginUrl, data;
-                if (usernameOrEmail.indexOf('@') === -1) {
-                    var username = usernameOrEmail;
+                if (nameOrEmail.indexOf('@') === -1) {
+                    var name = nameOrEmail;
                     loginUrl = url('login_username');
-                    data = { name: username, password: password };
+                    data = { name: name, password: password };
                 } else {
-                    var email = usernameOrEmail;
+                    var email = nameOrEmail;
                     loginUrl = url('login_email');
                     data = { email: email, password: password };
                 }
@@ -85,7 +85,7 @@ angular.module('pcApp.adhocracyEmbedder.services.adhocracy', [])
                 })
             };
 
-            client.register = function(username, email, password) {
+            client.register = function(name, email, password) {
                 return $http({
                     method: 'POST',
                     url: url('/principals/users/'),
@@ -93,7 +93,7 @@ angular.module('pcApp.adhocracyEmbedder.services.adhocracy', [])
                         "content_type": "adhocracy_core.resources.principal.IUser",
                         "data": {
                             "adhocracy_core.sheets.principal.IUserBasic": {
-                                "name": username
+                                "name": name
                             },
                             "adhocracy_core.sheets.principal.IUserExtended":{
                                 "email": email
@@ -103,7 +103,7 @@ angular.module('pcApp.adhocracyEmbedder.services.adhocracy', [])
                             }
                         }
                     }
-                });
+                })
             }
 
             return client;

--- a/app/modules/auth/auth.js
+++ b/app/modules/auth/auth.js
@@ -1,7 +1,7 @@
 var auth = angular.module('pcApp.auth', [
     'pcApp.auth.services.auth',
     'pcApp.auth.controllers.authControllers',
-    'pcApp.auth.directives.login'
+    'pcApp.auth.directives.loginRegister'
 ]);
 
 auth.config(function ($routeProvider) {

--- a/app/modules/auth/auth.js
+++ b/app/modules/auth/auth.js
@@ -11,8 +11,5 @@ auth.config(function ($routeProvider) {
         })
         .when('/register', {
             template: '<register></register>'
-        })
-        .when('/logout', {
-            template: '<div class="container"><h2>Logout</h2>Please log out by clicking on the logout link below:</div><adh-user-indicator></adh-user-indicator>'
         });
 });

--- a/app/modules/auth/controllers/authControllers.js
+++ b/app/modules/auth/controllers/authControllers.js
@@ -24,7 +24,7 @@ angular.module('pcApp.auth.controllers.authControllers', [
                 }
 
                 Auth.register(
-                    $scope.username,
+                    $scope.name,
                     $scope.email,
                     $scope.password
                 ).then(function () {
@@ -51,7 +51,7 @@ angular.module('pcApp.auth.controllers.authControllers', [
                 }
 
                 Auth.login(
-                    $scope.usernameOrEmail,
+                    $scope.nameOrEmail,
                     $scope.password
                 ).then(function (previousLocation) {
                     $location.url(previousLocation)

--- a/app/modules/auth/controllers/authControllers.js
+++ b/app/modules/auth/controllers/authControllers.js
@@ -1,27 +1,3 @@
-
-/** Unpack errors from A3 response. Unpacks A3 errors related
- *  to request body into an object of errors, with field names
- *  as keys.
- */
-var adhocracyErrorsToDict = function (response) {
-    if (response.data.status == 'error') {
-        var processedErrors = {}
-        var serverErrors = response.data.errors
-        for (errorIndex in serverErrors) {
-            if (serverErrors.hasOwnProperty(errorIndex)) {
-                var error = serverErrors[errorIndex];
-                if (error.location = 'body') {
-                    simpleName = error.name.split('.').pop();
-                    processedErrors[simpleName] = error.description;
-                }
-            }
-        }
-        return { pc_errors: processedErrors };
-    }
-    throw response;
-}
-
-
 angular.module('pcApp.auth.controllers.authControllers', [
     'pcApp.auth.services.auth',
 ])
@@ -54,8 +30,12 @@ angular.module('pcApp.auth.controllers.authControllers', [
                 ).then(function () {
                     $scope.completed = true;
                 }, function (response) {
-                    var errors = adhocracyErrorsToDict(response);
-                    $scope.serverErrors = errors.pc_errors;
+                    try {
+                        $scope.serverErrors = response.data.errorDict
+                    } catch (e) {
+                        $scope.serverErrors.$other = 'Unknown error.';
+                        throw e;
+                    }
                 })
             };
         }
@@ -82,8 +62,12 @@ angular.module('pcApp.auth.controllers.authControllers', [
                 ).then(function (previousLocation) {
                     $location.url(previousLocation);
                 }).catch(function (response) {
-                    var errors = adhocracyErrorsToDict(response);
-                    $scope.serverErrors = errors.pc_errors;
+                    try {
+                        $scope.serverErrors = response.data.errorDict;
+                    } catch (e) {
+                        $scope.serverErrors.$other = 'Unknown error.';
+                        throw e;
+                    }
                 })
             };
         }

--- a/app/modules/auth/controllers/authControllers.js
+++ b/app/modules/auth/controllers/authControllers.js
@@ -5,5 +5,61 @@ angular.module('pcApp.auth.controllers.authControllers', [
     .controller('UserState', [
         '$scope', 'Auth', function ($scope, Auth) {
             $scope.authState = Auth.state;
+            $scope.auth = Auth
+        }
+    ])
+    .controller('RegisterController', [
+        '$scope', '$location', 'Auth', function ($scope, $location, Auth) {
+            $scope.goToLogin = function ( path ) {
+                $location.path('/login');
+            };
+
+            $scope.$submitted = false;
+
+            $scope.register = function () {
+                $scope.$submitted = true;
+
+                if (!$scope.registerForm.$valid) {
+                    return false
+                }
+
+                Auth.register(
+                    $scope.username,
+                    $scope.email,
+                    $scope.password
+                ).then(function () {
+                    $scope.completed = true;
+                }, function (reason) {
+                    // FIXME: set errors
+                })
+            };
+        }
+    ])
+    .controller('LoginController', [
+        '$scope', '$location',  'Auth', function ($scope, $location, Auth) {
+            $scope.goToRegister = function ( path ) {
+                $location.path('/register');
+            };
+
+            $scope.$submitted = false;
+
+            $scope.login = function () {
+                $scope.$submitted = true;
+
+                if (!$scope.loginForm.$valid) {
+                    return false
+                }
+
+                Auth.login(
+                    $scope.usernameOrEmail,
+                    $scope.password
+                ).then(function (previousLocation) {
+                    $location.url(previousLocation)
+                }, function (reason) {
+                    // FIXME: set errors
+                })
+
+                return true
+            };
         }
     ]);

--- a/app/modules/auth/directives/login.js
+++ b/app/modules/auth/directives/login.js
@@ -44,31 +44,4 @@ angular.module('pcApp.auth.directives.login', [
                 });
             }
         };
-    })
-    .directive('adhUserIndicator', [
-        'Adhocracy', function (Adhocracy) {
-            return {
-                restrict: 'E',
-                link: function (scope, element, attrs) {
-                    Adhocracy.then(function (adh) {
-                        element.append(adh.getIframe('user-indicator', {noheader: true}))
-                    });
-                }
-            };
-        }
-    ])
-    .directive('adhCrossWindowChannel', [
-        'Adhocracy', function (Adhocracy) {
-            return {
-                restrict: 'E',
-                link: function (scope, element, attrs) {
-                    Adhocracy.then(function (adh) {
-                        element.append(adh.getIframe('empty', {
-                            noheader: true,
-                            nocenter: true
-                        }))
-                    });
-                }
-            };
-        }
-    ]);
+    });

--- a/app/modules/auth/directives/login.js
+++ b/app/modules/auth/directives/login.js
@@ -2,30 +2,49 @@ angular.module('pcApp.auth.directives.login', [
     'pcApp.auth.services.auth',
 ])
 
-    .directive('login', [
-        'Adhocracy', function (Adhocracy) {
-            return {
-                restrict: 'E',
-                link: function (scope, element, attrs) {
-                    Adhocracy.then(function (adh) {
-                        element.append(adh.getIframe('login', {noheader: true}))
-                    });
-                }
-            };
-        }
-    ])
-    .directive('register', [
-        'Adhocracy', function (Adhocracy) {
-            return {
-                restrict: 'E',
-                link: function (scope, element, attrs) {
-                    Adhocracy.then(function (adh) {
-                        element.append(adh.getIframe('register', {noheader: true}))
-                    });
-                }
-            };
-        }
-    ])
+    .directive('login', function () {
+        return {
+            restrict: 'E',
+            templateUrl: 'modules/auth/partials/login.html',
+        };
+    })
+    .directive('register', function (Adhocracy) {
+        return {
+            restrict: 'E',
+            templateUrl: 'modules/auth/partials/register.html',
+        };
+    })
+    .directive("passwordVerify", function() {
+        return {
+            require: "ngModel",
+            scope: {
+                passwordVerify: '='
+            },
+            link: function(scope, element, attrs, ctrl) {
+                scope.$watch(function() {
+                    var combined;
+
+                    if (scope.passwordVerify || ctrl.$viewValue) {
+                        combined = scope.passwordVerify + '_' + ctrl.$viewValue;
+                    }
+                    return combined;
+                }, function(value) {
+                    if (value) {
+                        ctrl.$parsers.unshift(function(viewValue) {
+                            var origin = scope.passwordVerify;
+                            if (origin !== viewValue) {
+                                ctrl.$setValidity("passwordVerify", false);
+                                return undefined;
+                            } else {
+                                ctrl.$setValidity("passwordVerify", true);
+                                return viewValue;
+                            }
+                        });
+                    }
+                });
+            }
+        };
+    })
     .directive('adhUserIndicator', [
         'Adhocracy', function (Adhocracy) {
             return {

--- a/app/modules/auth/directives/loginRegister.js
+++ b/app/modules/auth/directives/loginRegister.js
@@ -1,4 +1,4 @@
-angular.module('pcApp.auth.directives.login', [
+angular.module('pcApp.auth.directives.loginRegister', [
     'pcApp.auth.services.auth',
 ])
 

--- a/app/modules/auth/directives/loginRegister.js
+++ b/app/modules/auth/directives/loginRegister.js
@@ -8,7 +8,7 @@ angular.module('pcApp.auth.directives.loginRegister', [
             templateUrl: 'modules/auth/partials/login.html',
         };
     })
-    .directive('register', function (Adhocracy) {
+    .directive('register', function () {
         return {
             restrict: 'E',
             templateUrl: 'modules/auth/partials/register.html',

--- a/app/modules/auth/partials/login.html
+++ b/app/modules/auth/partials/login.html
@@ -27,7 +27,7 @@
                     <span ng-show="serverErrors.password">{{ serverErrors.password }}</span>
                 </div>
                 <div class="form-group">
-                    <a href class="btn btn-primary" ng-disabled="!loginForm.$valid" ng-click="login()">Login</a>
+                    <input type="submit" name="submit" class="btn btn-primary" ng-disabled="!loginForm.$valid" ng-click="login()" value="Login" />
                 </div>
             </form>
         </div>

--- a/app/modules/auth/partials/login.html
+++ b/app/modules/auth/partials/login.html
@@ -1,0 +1,34 @@
+<div class="container">
+    <div class="container-header">
+        <h3>Login</h3>
+        <div class="subtitle-help">
+            <h4>
+                <div class="fonticon fonticon-help help-switch" ng-click="help=!help"></div>
+                <span class="ng-scope">Enter your credentials</span>
+            </h4>
+            <div ng-class="{active: help}" class="help-text">
+                <div class="fonticon fonticon-close" ng-click="help=!help"></div>
+                <p>Indicator herlp.</p>
+            </div>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-sm-4 col-sm-offset-4">
+            <form ng-controller="LoginController" ng-submit="login()" name="loginForm" novalidate>
+                <div class="form-group">
+                    <label for="usernameOrEmail">Username or Email</label>
+                    <input class="form-control" type="text" ng-model="usernameOrEmail" id="usernameOrEmail" name="usernameOrEmail" ng-required="true" />
+                    <span ng-show="(loginForm.usernameOrEmail.$dirty || $submitted) && loginForm.usernameOrEmail.$error.required">The value is required!</span>
+                </div>
+                <div class="form-group">
+                    <label for="password">Password</label>
+                    <input class="form-control" type="password" ng-model="password" id="password" name="usernameOrEmail" ng-required="true" />
+                    <span ng-show="(loginForm.password.$dirty || $submitted) && loginform.password.$error.required">The value is required!</span>
+                </div>
+                <div class="form-group">
+                    <a href class="btn btn-success" ng-disabled="!registerForm.$valid">Login</a>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>

--- a/app/modules/auth/partials/login.html
+++ b/app/modules/auth/partials/login.html
@@ -14,19 +14,20 @@
     </div>
     <div class="row">
         <div class="col-sm-4 col-sm-offset-4">
-            <form ng-controller="LoginController" ng-submit="login()" name="loginForm" novalidate>
+            <form ng-controller="LoginController" name="loginForm" novalidate>
                 <div class="form-group">
-                    <label for="usernameOrEmail">Username or Email</label>
-                    <input class="form-control" type="text" ng-model="usernameOrEmail" id="usernameOrEmail" name="usernameOrEmail" ng-required="true" />
-                    <span ng-show="(loginForm.usernameOrEmail.$dirty || $submitted) && loginForm.usernameOrEmail.$error.required">The value is required!</span>
+                    <label for="nameOrEmail">Name or Email</label>
+                    <input class="form-control" type="text" ng-model="nameOrEmail" id="nameOrEmail" name="nameOrEmail" ng-required="true" />
+                    <span ng-show="(loginForm.nameOrEmail.$dirty || $submitted) && loginForm.nameOrEmail.$error.required">The value is required!</span>
                 </div>
                 <div class="form-group">
                     <label for="password">Password</label>
-                    <input class="form-control" type="password" ng-model="password" id="password" name="usernameOrEmail" ng-required="true" />
-                    <span ng-show="(loginForm.password.$dirty || $submitted) && loginform.password.$error.required">The value is required!</span>
+                    <input class="form-control" type="password" ng-model="password" id="password" name="nameOrEmail" ng-required="true" />
+                    <span ng-show="(loginForm.password.$dirty || $submitted) && loginForm.password.$error.required">The value is required!</span>
+                    <span ng-show="serverErrors.password">{{ serverErrors.password }}</span>
                 </div>
                 <div class="form-group">
-                    <a href class="btn btn-success" ng-disabled="!registerForm.$valid">Login</a>
+                    <a href class="btn btn-primary" ng-disabled="!loginForm.$valid" ng-click="login()">Login</a>
                 </div>
             </form>
         </div>

--- a/app/modules/auth/partials/login.html
+++ b/app/modules/auth/partials/login.html
@@ -15,6 +15,7 @@
     <div class="row">
         <div class="col-sm-4 col-sm-offset-4">
             <form ng-controller="LoginController" name="loginForm" novalidate>
+                <div ng-show="serverErrors.$other">{{ serverErrors.$other }}</div>
                 <div class="form-group">
                     <label for="nameOrEmail">Name or Email</label>
                     <input class="form-control" type="text" ng-model="nameOrEmail" id="nameOrEmail" name="nameOrEmail" ng-required="true" />

--- a/app/modules/auth/partials/register.html
+++ b/app/modules/auth/partials/register.html
@@ -15,6 +15,7 @@
     <div class="row" ng-controller="RegisterController">
         <div class="col-sm-4 col-sm-offset-4" >
             <form ng-hide="completed" name="registerForm" novalidate>
+                <div ng-show="serverErrors.$other">{{ serverErrors.$other }}</div>
                 <div class="form-group">
                     <label for="name">Name</label>
                     <input class="form-control" type="text" ng-model="name" id="name" name="name" ng-required="true"/>

--- a/app/modules/auth/partials/register.html
+++ b/app/modules/auth/partials/register.html
@@ -16,15 +16,17 @@
         <div class="col-sm-4 col-sm-offset-4" >
             <form ng-hide="completed" name="registerForm" novalidate>
                 <div class="form-group">
-                    <label for="username">Username</label>
-                    <input class="form-control" type="text" ng-model="username" id="username" name="username" ng-required="true"/>
-                    <span ng-show="(registerForm.username.$dirty || $submitted) && registerForm.username.$error.required">The value is required!</span>
+                    <label for="name">Name</label>
+                    <input class="form-control" type="text" ng-model="name" id="name" name="name" ng-required="true"/>
+                    <span ng-show="(registerForm.name.$dirty || $submitted) && registerForm.name.$error.required">The value is required!</span>
+                    <span ng-show="serverErrors.name">{{ serverErrors.name }}</span>
                 </div>
                 <div class="form-group">
                     <label for="email">Email</label>
                     <input class="form-control" type="email" ng-model="email" id="email" name="email" ng-required="true" />
                     <span ng-show="(registerForm.email.$dirty || $submitted) && registerForm.email.$error.required">The value is required!</span>
                     <span ng-show="registerForm.email.$error.email"> Not valid email!</span>
+                    <span ng-show="serverErrors.email">{{ serverErrors.email }}</span>
                 </div>
                 <div class="form-group">
                     <label for="password" >Password</label>
@@ -32,6 +34,7 @@
                            ng-model="password" ng-required="true"/>
                     <span ng-show="(registerForm.password.$dirty || $submitted) && registerForm.password.$error.required">The value is required!</span>
                     <span ng-show="(registerForm.password.$dirty || $submitted) && registerForm.password.$error.minlength">The password is to short!</span>
+                    <span ng-show="serverErrors.password">{{ serverErrors.password }}</span>
                 </div>
                 <div class="form-group">
                     <label for="passwordConfirm">Password (again)</label>

--- a/app/modules/auth/partials/register.html
+++ b/app/modules/auth/partials/register.html
@@ -1,0 +1,55 @@
+<div class="container">
+    <div class="container-header">
+        <h3>Signup</h3>
+        <div class="subtitle-help">
+            <h4>
+                <div class="fonticon fonticon-help help-switch" ng-click="help=!help"></div>
+                <span class="ng-scope">Create a new user</span>
+            </h4>
+            <div ng-class="{active: help}" class="help-text">
+                <div class="fonticon fonticon-close" ng-click="help=!help"></div>
+                <p>Indicator herlp.</p>
+            </div>
+        </div>
+    </div>
+    <div class="row" ng-controller="RegisterController">
+        <div class="col-sm-4 col-sm-offset-4" >
+            <form ng-hide="completed" name="registerForm" novalidate>
+                <div class="form-group">
+                    <label for="username">Username</label>
+                    <input class="form-control" type="text" ng-model="username" id="username" name="username" ng-required="true"/>
+                    <span ng-show="(registerForm.username.$dirty || $submitted) && registerForm.username.$error.required">The value is required!</span>
+                </div>
+                <div class="form-group">
+                    <label for="email">Email</label>
+                    <input class="form-control" type="email" ng-model="email" id="email" name="email" ng-required="true" />
+                    <span ng-show="(registerForm.email.$dirty || $submitted) && registerForm.email.$error.required">The value is required!</span>
+                    <span ng-show="registerForm.email.$error.email"> Not valid email!</span>
+                </div>
+                <div class="form-group">
+                    <label for="password" >Password</label>
+                    <input class="form-control" type="password" id="password" name="password"
+                           ng-model="password" ng-required="true"/>
+                    <span ng-show="(registerForm.password.$dirty || $submitted) && registerForm.password.$error.required">The value is required!</span>
+                    <span ng-show="(registerForm.password.$dirty || $submitted) && registerForm.password.$error.minlength">The password is to short!</span>
+                </div>
+                <div class="form-group">
+                    <label for="passwordConfirm">Password (again)</label>
+                    <input class="form-control" id="passwordConfirm" type="password" ng-model="passwordConfirm" name="passwordConfirm" ng-required="true" data-password-verify="password"/>
+                    <span ng-show="(registerForm.passwordConfirm.$dirty || $submitted) && registerForm.passwordConfirm.$error.required">The value is required!</span>
+                    <span ng-show="registerForm.passwordConfirm.$error.passwordVerify">Fields are not equal!</span>
+                </div>
+                <div class="form-group">
+                    <input type="checkbox" ng-model="acceptTerms" ng-required="true" /> I accept the <a target="_blank" href="#!/terms-of-use">terms and conditions<a>
+                    <span ng-show="$submitted && registerForm.acceptTerms.$error.required">The value is required!</span>
+                </div>
+                <div class="form-group">
+                    <a href class="btn btn-primary" ng-disabled="!registerForm.$valid" ng-click="register()">Register</a>
+                </div>
+            </form>
+        </div>
+        <div ng-show="completed" class="alert alert-success col-sm-6 col-sm-offset-2" role="alert">
+            <strong>Registration completed.</strong>Check your email for the activation link and proceed to <a href ng-click="goToLogin()">login</a>.
+        </div>
+    </div>
+</div>

--- a/app/modules/auth/partials/register.html
+++ b/app/modules/auth/partials/register.html
@@ -47,7 +47,7 @@
                     <span ng-show="$submitted && registerForm.acceptTerms.$error.required">The value is required!</span>
                 </div>
                 <div class="form-group">
-                    <a href class="btn btn-primary" ng-disabled="!registerForm.$valid" ng-click="register()">Register</a>
+                    <input type="submit" name="submit" class="btn btn-primary" ng-disabled="!registerForm.$valid" ng-click="register()" value="Register" />
                 </div>
             </form>
         </div>

--- a/app/modules/auth/services/auth.js
+++ b/app/modules/auth/services/auth.js
@@ -8,7 +8,6 @@ angular.module('pcApp.auth.services.auth', [
         'API_CONF',
         '$rootScope',
         '$http',
-        '$location',
         '$q',
         '$localStorage',
         function (Adhocracy, AdhocracyClient, API_CONF, $rootScope, $http, $q, $localStorage) {

--- a/app/modules/auth/services/auth.js
+++ b/app/modules/auth/services/auth.js
@@ -126,8 +126,8 @@ angular.module('pcApp.auth.services.auth', [
             /** Wrapper to make A3 auth features pluggable. Calls directly A3
              *  specific login code and A3 specific code to fetch user data.
              */
-            Auth.login = function (usernameOrEmail, password) {
-                return AdhocracyClient.create_session(usernameOrEmail, password)
+            Auth.login = function (nameOrEmail, password) {
+                return AdhocracyClient.create_session(nameOrEmail, password)
                     .then(function (session) {
                         return AdhocracyClient.validate_session(session)
                             .then(function (userData) {
@@ -142,8 +142,8 @@ angular.module('pcApp.auth.services.auth', [
             /** Wrapper to make A3 auth features pluggable. Calls directly A3
              *  specific register code.
              */
-            Auth.register = function (username, email, password) {
-                return AdhocracyClient.register(username, email, password)
+            Auth.register = function (name, email, password) {
+                return AdhocracyClient.register(name, email, password)
             };
 
             Auth.logout = function () {

--- a/app/modules/auth/services/auth.js
+++ b/app/modules/auth/services/auth.js
@@ -3,14 +3,12 @@ angular.module('pcApp.auth.services.auth', [
 ])
 
     .factory('Auth', [
-        'Adhocracy',
         'AdhocracyClient',
-        'API_CONF',
+        'AdhocracyCrossWindowChannel',
         '$rootScope',
         '$http',
-        '$q',
         '$localStorage',
-        function (Adhocracy, AdhocracyClient, API_CONF, $rootScope, $http, $q, $localStorage) {
+        function (AdhocracyClient, AdhocracyCrossWindowChannel, $rootScope, $http, $localStorage) {
 
             var last = undefined;
 
@@ -71,7 +69,11 @@ angular.module('pcApp.auth.services.auth', [
                 }
 
                 // setup a3 session
-                // FIXME: missing
+                AdhocracyCrossWindowChannel.then(function (adhCWC) {
+                    adhCWC.load(function() {
+                        adhCWC[0].setToken(token)
+                    });
+                })
 
                 setupUserData(userData, doNotStore);
             }
@@ -94,7 +96,11 @@ angular.module('pcApp.auth.services.auth', [
                 Auth.state.userData = undefined
                 Auth.state.isAdmin = undefined
 
-                // FIXME: teardown adhocracy
+                AdhocracyCrossWindowChannel.then(function (adhCWC) {
+                    adhCWC.load(function() {
+                        adhCWC[0].deleteToken()
+                    });
+                })
 
                 delete $localStorage.token
                 delete $localStorage.userPath
@@ -174,70 +180,6 @@ angular.module('pcApp.auth.services.auth', [
                         teardownSession();
                     })
             }
-
-
-
-            //     // NOTE: _login and _logout are only meant to be called through
-            //     // the AdhocracySDK.
-
-            //     _login: function (userData, token, userPath) {
-            //         return $http.get(API_CONF.ADHOCRACY_BACKEND_URL + "/principals/groups/gods/").then(function (response) {
-            //             var godsGroup = response.data;
-            //             var godsGroupSheet = godsGroup.data["adhocracy_core.sheets.principal.IGroup"];
-            //             var isAdmin = (_.contains(godsGroupSheet.roles, "god") && _.contains(godsGroupSheet.users, userPath));
-            //             var deferred = $q.defer();
-
-            //             _.defer(function () {
-            //                 $rootScope.$apply(function () {
-            //                     Auth.state.loggedIn = true;
-            //                     Auth.state.userData = userData;
-            //                     Auth.state.userPath = userPath;
-            //                     Auth.state.isAdmin = isAdmin;
-
-            //                     $http.defaults.headers.common["X-User-Token"] = token;
-            //                     $http.defaults.headers.common["X-User-Path"] = userPath;
-
-            //                     deferred.resolve(true)
-            //                 });
-            //             });
-
-            //             return deferred.promise;
-            //         });
-            //     },
-
-            //     _logout: function () {
-            //         _.defer(function () {
-            //             $rootScope.$apply(function () {
-            //                 Auth.state.loggedIn = false;
-            //                 Auth.state.userData = undefined;
-            //                 Auth.state.userPath = undefined;
-            //                 Auth.state.isAdmin = false;
-
-            //                 delete $http.defaults.headers.common["X-User-Token"];
-            //                 delete $http.defaults.headers.common["X-User-Path"];
-            //             });
-            //         });
-            //     }
-            // };
-
-            // Adhocracy.then(function (adh) {
-            //     adh.registerMessageHandler('login', function (data) {
-            //         Auth._login(data.userData, data.token, data.userPath).then(function (ready) {
-
-            //             if (($location.path() === '/login') || ($location.path() === '/register')) {
-            //                 $location.url(last || '/');
-            //                 last = undefined;
-            //             }
-            //         });
-            //     });
-            //     adh.registerMessageHandler('logout', function (data) {
-            //         Auth._logout();
-
-            //         if ($location.path() === '/logout') {
-            //             $location.path(last || '/');
-            //         }
-            //     });
-            // });
 
             return Auth;
         }

--- a/app/modules/auth/services/auth.js
+++ b/app/modules/auth/services/auth.js
@@ -8,8 +8,9 @@ angular.module('pcApp.auth.services.auth', [
         '$rootScope',
         '$http',
         '$localStorage',
-        function (AdhocracyClient, AdhocracyCrossWindowChannel, $rootScope, $http, $localStorage) {
-
+        'API_CONF',
+        function (AdhocracyClient, AdhocracyCrossWindowChannel, $rootScope,
+                  $http, $localStorage, API_CONF) {
             var last = undefined;
 
             $rootScope.$on("$locationChangeSuccess",

--- a/app/modules/auth/services/auth.js
+++ b/app/modules/auth/services/auth.js
@@ -69,10 +69,8 @@ angular.module('pcApp.auth.services.auth', [
                 }
 
                 // setup a3 session
-                AdhocracyCrossWindowChannel.then(function (adhCWC) {
-                    adhCWC.load(function() {
-                        adhCWC[0].setToken(token)
-                    });
+                AdhocracyCrossWindowChannel.then(function (channel) {
+                    channel.setToken(token, userPath)
                 })
 
                 setupUserData(userData, doNotStore);
@@ -96,10 +94,8 @@ angular.module('pcApp.auth.services.auth', [
                 Auth.state.userData = undefined
                 Auth.state.isAdmin = undefined
 
-                AdhocracyCrossWindowChannel.then(function (adhCWC) {
-                    adhCWC.load(function() {
-                        adhCWC[0].deleteToken()
-                    });
+                AdhocracyCrossWindowChannel.then(function (channel) {
+                    channel.deleteToken();
                 })
 
                 delete $localStorage.token

--- a/app/modules/auth/services/auth.js
+++ b/app/modules/auth/services/auth.js
@@ -4,12 +4,14 @@ angular.module('pcApp.auth.services.auth', [
 
     .factory('Auth', [
         'Adhocracy',
+        'AdhocracyClient',
         'API_CONF',
         '$rootScope',
         '$http',
         '$location',
         '$q',
-        function (Adhocracy, API_CONF, $rootScope, $http, $location, $q) {
+        '$localStorage',
+        function (Adhocracy, AdhocracyClient, API_CONF, $rootScope, $http, $q, $localStorage) {
 
             var last = undefined;
 
@@ -49,68 +51,194 @@ angular.module('pcApp.auth.services.auth', [
                         return userPath === object.creator_path;
                     }
                 },
-
-                // NOTE: _login and _logout are only meant to be called through
-                // the AdhocracySDK.
-
-                _login: function (userData, token, userPath) {
-                    return $http.get(API_CONF.ADHOCRACY_BACKEND_URL + "/principals/groups/gods/").then(function (response) {
-                        var godsGroup = response.data;
-                        var godsGroupSheet = godsGroup.data["adhocracy_core.sheets.principal.IGroup"];
-                        var isAdmin = (_.contains(godsGroupSheet.roles, "god") && _.contains(godsGroupSheet.users, userPath));
-                        var deferred = $q.defer();
-
-                        _.defer(function () {
-                            $rootScope.$apply(function () {
-                                Auth.state.loggedIn = true;
-                                Auth.state.userData = userData;
-                                Auth.state.userPath = userPath;
-                                Auth.state.isAdmin = isAdmin;
-
-                                $http.defaults.headers.common["X-User-Token"] = token;
-                                $http.defaults.headers.common["X-User-Path"] = userPath;
-
-                                deferred.resolve(true)
-                            });
-                        });
-
-                        return deferred.promise;
-                    });
-                },
-
-                _logout: function () {
-                    _.defer(function () {
-                        $rootScope.$apply(function () {
-                            Auth.state.loggedIn = false;
-                            Auth.state.userData = undefined;
-                            Auth.state.userPath = undefined;
-                            Auth.state.isAdmin = false;
-
-                            delete $http.defaults.headers.common["X-User-Token"];
-                            delete $http.defaults.headers.common["X-User-Path"];
-                        });
-                    });
-                }
             };
 
-            Adhocracy.then(function (adh) {
-                adh.registerMessageHandler('login', function (data) {
-                    Auth._login(data.userData, data.token, data.userPath).then(function (ready) {
+            var setupSession = function(session, userData, doNotStore) {
+                token = session.token
+                userPath = session.userPath
 
-                        if (($location.path() === '/login') || ($location.path() === '/register')) {
-                            $location.url(last || '/');
-                            last = undefined;
-                        }
+                // setup headers for backend communication
+                $http.defaults.headers.common[AdhocracyClient.headerNames.token] = token;
+                $http.defaults.headers.common[AdhocracyClient.headerNames.userPath] = userPath;
+
+                // setup auth state
+                Auth.state.loggedIn = true;
+                Auth.state.usetPath = userPath;
+
+                // store session and user data to local store
+                if (!doNotStore) {
+                    $localStorage.token = token;
+                    $localStorage.userPath = userPath;
+                }
+
+                // setup a3 session
+                // FIXME: missing
+
+                setupUserData(userData, doNotStore);
+            }
+
+            var setupUserData = function (userData, doNotStore) {
+                if (!doNotStore) {
+                    $localStorage.userData = userData;
+                }
+                Auth.state.userData = userData;
+                Auth.state.isAdmin = userData.roles.indexOf('god') !== -1;
+            }
+
+            var teardownSession = function() {
+                // the opposite of setup session
+                delete $http.defaults.headers.common[AdhocracyClient.headerNames.token];
+                delete $http.defaults.headers.common[AdhocracyClient.headerNames.userPath];
+
+                Auth.state.loggedIn = false
+                Auth.state.usetPath = undefined
+                Auth.state.userData = undefined
+                Auth.state.isAdmin = undefined
+
+                // FIXME: teardown adhocracy
+
+                delete $localStorage.token
+                delete $localStorage.userPath
+                delete $localStorage.userData
+            }
+
+            var loadLocalSession = function() {
+                if (!$localStorage.token || !$localStorage.userPath) {
+                    return null
+                }
+
+                // userData will be refreshed during session validation
+                var fallbackUserData = {
+                    username: 'unkown user',
+                    roles: [],
+                    email: 'unkown email'
+                }
+
+                return {
+                    session: {
+                        token: $localStorage.token,
+                        userPath: $localStorage.userPath,
+                    },
+                    userData: $localStorage.userData || fallbackUserData
+                }
+            }
+
+            /** Wrapper to make A3 auth features pluggable. Calls directly A3
+             *  specific login code and A3 specific code to fetch user data.
+             */
+            Auth.login = function (usernameOrEmail, password) {
+                return AdhocracyClient.create_session(usernameOrEmail, password)
+                    .then(function (session) {
+                        return AdhocracyClient.validate_session(session)
+                            .then(function (userData) {
+                                setupSession(session, userData)
+                                beforeLogin = last || '/';
+                                last = undefined;
+                                return beforeLogin;
+                            });
                     });
-                });
-                adh.registerMessageHandler('logout', function (data) {
-                    Auth._logout();
+            };
 
-                    if ($location.path() === '/logout') {
-                        $location.path(last || '/');
-                    }
-                });
-            });
+            /** Wrapper to make A3 auth features pluggable. Calls directly A3
+             *  specific register code.
+             */
+            Auth.register = function (username, email, password) {
+                return AdhocracyClient.register(username, email, password)
+            };
+
+            Auth.logout = function () {
+                teardownSession();
+            };
+
+            /** Reads session data from local storage and validates it against
+             *  A3 backend service
+             */
+            Auth.recoverSession = function () {
+                var local = loadLocalSession();
+
+                if (!local) {
+                    teardownSession();
+                    return null;
+                }
+
+                var session = local.session;
+                var userData = local.userData;
+                var doNotStore = true;
+
+                setupSession(session, userData, doNotStore);
+
+                return AdhocracyClient.validate_session(session)
+                    .then(function (userData) {
+                        setupUserData(userData);
+                    }, function (response) {
+                        console.log("Session couldn't be validated", response)
+                        teardownSession();
+                    })
+            }
+
+
+
+            //     // NOTE: _login and _logout are only meant to be called through
+            //     // the AdhocracySDK.
+
+            //     _login: function (userData, token, userPath) {
+            //         return $http.get(API_CONF.ADHOCRACY_BACKEND_URL + "/principals/groups/gods/").then(function (response) {
+            //             var godsGroup = response.data;
+            //             var godsGroupSheet = godsGroup.data["adhocracy_core.sheets.principal.IGroup"];
+            //             var isAdmin = (_.contains(godsGroupSheet.roles, "god") && _.contains(godsGroupSheet.users, userPath));
+            //             var deferred = $q.defer();
+
+            //             _.defer(function () {
+            //                 $rootScope.$apply(function () {
+            //                     Auth.state.loggedIn = true;
+            //                     Auth.state.userData = userData;
+            //                     Auth.state.userPath = userPath;
+            //                     Auth.state.isAdmin = isAdmin;
+
+            //                     $http.defaults.headers.common["X-User-Token"] = token;
+            //                     $http.defaults.headers.common["X-User-Path"] = userPath;
+
+            //                     deferred.resolve(true)
+            //                 });
+            //             });
+
+            //             return deferred.promise;
+            //         });
+            //     },
+
+            //     _logout: function () {
+            //         _.defer(function () {
+            //             $rootScope.$apply(function () {
+            //                 Auth.state.loggedIn = false;
+            //                 Auth.state.userData = undefined;
+            //                 Auth.state.userPath = undefined;
+            //                 Auth.state.isAdmin = false;
+
+            //                 delete $http.defaults.headers.common["X-User-Token"];
+            //                 delete $http.defaults.headers.common["X-User-Path"];
+            //             });
+            //         });
+            //     }
+            // };
+
+            // Adhocracy.then(function (adh) {
+            //     adh.registerMessageHandler('login', function (data) {
+            //         Auth._login(data.userData, data.token, data.userPath).then(function (ready) {
+
+            //             if (($location.path() === '/login') || ($location.path() === '/register')) {
+            //                 $location.url(last || '/');
+            //                 last = undefined;
+            //             }
+            //         });
+            //     });
+            //     adh.registerMessageHandler('logout', function (data) {
+            //         Auth._logout();
+
+            //         if ($location.path() === '/logout') {
+            //             $location.path(last || '/');
+            //         }
+            //     });
+            // });
 
             return Auth;
         }

--- a/app/modules/deliberation/directives/requestService.js
+++ b/app/modules/deliberation/directives/requestService.js
@@ -3,14 +3,14 @@ angular.module('pcApp.deliberation.directives.requestService', [
 ])
 
     .directive('requestService', [
-        'API_CONF', 'Adhocracy', function (API_CONF, Adhocracy) {
+        'API_CONF', 'AdhocracySdk', function (API_CONF, AdhocracySdk) {
             return {
                 restrict: 'E',
                 scope: {
                     key: '@'
                 },
                 link: function (scope, element, attrs) {
-                    Adhocracy.then(function (adh) {
+                    AdhocracySdk.then(function (adh) {
                         element.append(adh.getIframe('pcompass', {
                             "initialUrl": '/r/organisation/pcompass/',
                             autoresize: false,
@@ -23,4 +23,3 @@ angular.module('pcApp.deliberation.directives.requestService', [
             };
         }
     ]);
-

--- a/app/modules/deliberation/directives/showDiscussion.js
+++ b/app/modules/deliberation/directives/showDiscussion.js
@@ -3,7 +3,7 @@ angular.module('pcApp.deliberation.directives.showDiscussion', [
 ])
 
     .directive('showDiscussion', [
-        'API_CONF', 'Adhocracy', function (API_CONF, Adhocracy) {
+        'API_CONF', 'AdhocracySdk', function (API_CONF, AdhocracySdk) {
             return {
                 restrict: 'E',
                 scope: {
@@ -15,7 +15,7 @@ angular.module('pcApp.deliberation.directives.showDiscussion', [
                     if(scope.autoResize == false) {
                         autoResize = false;
                     }
-                    Adhocracy.then(function (adh) {
+                    AdhocracySdk.then(function (adh) {
                         element.append(adh.getIframe('create-or-show-comment-listing', {
                             "pool-path": API_CONF.ADHOCRACY_BACKEND_URL + '/adhocracy/',
                             key: scope.key,


### PR DESCRIPTION
- login directly from pc-frontend (no more iframe messaging needed for login and register)
- store session data in local storage
- set a3 session from pc-frontend
- works only with ~~liqd/adhocracy3#cc1963b973b92bfddeda9b33cf1f7d1d455ab033~~ 37b0b92ad14aaa5044ea3b0786cc29040ffb45de
