### PR TITLE
Fix order by Date and Own Draft content in browse 

### DIFF
--- a/app/modules/search/controllers/searchControllers.js
+++ b/app/modules/search/controllers/searchControllers.js
@@ -137,6 +137,11 @@
                 field: ["creator_path", "userPath"],
                 size: 200,
                 disable: true
+            },
+            draft: {
+                label: 'Draft',
+                field: ["is_draft"],
+                disable: true
             }
         };
 
@@ -577,6 +582,19 @@
 
         $scope.isOwnContentEnabled = function () {
             return userId === ("0000000"+getUserId()).slice(-7);
+        };
+
+        $scope.isDraftOnlyEnabled = function() {
+            return facetsSelected['draft'] && facetsSelected['draft'].indexOf("T") !== -1;
+        };
+
+        $scope.ownDraftOnlyChanged = function ($event) {
+            if (!isloggedIn()) return;
+            var checkbox = $event.target;
+            var checked = checkbox.checked;
+            facetSet("draft", "T", checked);
+            $location.search("_draft", facetsSelected["draft"]);
+            goToPage();
         };
 
         $scope.init = function() {

--- a/app/modules/search/controllers/searchControllers.js
+++ b/app/modules/search/controllers/searchControllers.js
@@ -29,8 +29,11 @@
             id: 'Title',
             name: 'Title'
         }, {
-            id: 'Date',
-            name: 'Date Created'
+            id: 'DateDesc',
+            name: 'Date Added Desc.'
+        }, {
+            id: 'DateAsc',
+            name: 'Date Added Asc.'
         }, {
             id: 'CommentsDesc',
             name: 'Comments Desc.'
@@ -457,6 +460,18 @@
                 var sort = ["_score"];
             } else if ($scope.sortByItem == 'Title') {
                 var sort = ["title.lower_case_sort"];
+            } else if ($scope.sortByItem == 'DateDesc') {
+                var sort = [{
+                    "date_created": {
+                        "order": "desc"
+                    }
+                }];
+            } else if ($scope.sortByItem == 'DateAsc') {
+                var sort = [{
+                    "date_created": {
+                        "order": "asc"
+                    }
+                }];
             } else if ($scope.sortByItem == 'CommentsDesc') {
                 var sort = [{
                     "commentsCount": {

--- a/app/modules/search/partials/browse.html
+++ b/app/modules/search/partials/browse.html
@@ -159,6 +159,10 @@
                                         {{ searchResult['_source']['startEventDate']|date:'dd-MM-yyyy'}}
                                     </div>
                                     <div class="key-field">
+                                        <label class="key-field-title">Added: </label>
+                                        {{ searchResult['_source']['date_created']|date:'dd-MM-yyyy'}}
+                                    </div>
+                                    <div class="key-field">
                                         <label class="key-field-title">Comments: </label>
                                         {{ searchResult['_source']['commentsCount']}}
                                     </div>
@@ -202,7 +206,11 @@
 
                                     <div class="key-field">
                                         <label class="key-field-title">Keywords: </label>
-                                        {{ searchResult['_source']['keywords']|date:'dd-MM-yyyy'}}
+                                        {{ searchResult['_source']['keywords']}}
+                                    </div>
+                                    <div class="key-field">
+                                        <label class="key-field-title">Added: </label>
+                                        {{ searchResult['_source']['date_created']|date:'dd-MM-yyyy'}}
                                     </div>
                                     <div class="key-field">
                                         <label class="key-field-title">Comments: </label>
@@ -227,7 +235,7 @@
                                     </div>
                                     <div class="key-field">
                                         <label class="key-field-title">Added: </label>
-                                        {{ searchResult['_source']['issued']|date:'dd-MM-yyyy'}}
+                                        {{ searchResult['_source']['date_created']|date:'dd-MM-yyyy'}}
                                     </div>
                                     <div class="key-field">
                                         <label class="key-field-title">Comments: </label>

--- a/app/modules/search/partials/browse.html
+++ b/app/modules/search/partials/browse.html
@@ -280,6 +280,12 @@
                              <span class="ellipsis">My own content</span>
                         </label>
                     </li>
+                    <li>
+                        <input type="checkbox" id="draft_only" ng-checked="isDraftOnlyEnabled()" ng-click="ownDraftOnlyChanged($event)">
+                        <label for="draft_only" tooltip-placement="right" tooltip="Show only my draft content" tooltip-append-to-body="true">
+                             <span class="ellipsis">My draft content</span>
+                        </label>
+                    </li>
                 </ul>
             </div>
             <div ng-repeat="facetCategory in facetCategories | orderBy: 'order'" ng-if="facetCategory.results>0" class="browse-filters-block">


### PR DESCRIPTION
It's now "Date Added" and can select the order (Desc. Asc.)
Added the date info in the results for events, fcm and stories.
policycompass/policycompass#673

Added option on browse to filter drafts
It appears only on logged on users.
policycompass/policycompass#657
policycompass/policycompass#452